### PR TITLE
remove files not needed anymore by nova

### DIFF
--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -87,7 +87,8 @@ class ProtTsCtffind(ProtTsEstimateCTF):
             # Move files we want to keep
             pwutils.moveFile(outputPsd, self._getExtraPath(tsId))
             pwutils.moveFile(outputPsd.replace('.mrc', '.txt'),
-                             self._getExtraPath(tsId))
+                             self._getTmpPath())
+
         except Exception as ex:
             print("ERROR: Ctffind has failed for %s" % tiFn)
 


### PR DESCRIPTION
After some design changes in novaCtf, the output info .txt file is not needed anymore, so it will be moved to tmp folder. Also, this will fix some errors in the output CTF model (introduced by my previous PR)