### PR TITLE
3.0.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.0.9 - fix race conditions after adding amplitude spectra option
 3.0.8 - add calculate from amplitude spectra option, update default values
 3.0.7 - minor fixes
 3.0.6 - add ctffind4 4.1.14 binaries

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,27 @@ cisTEM plugin
 
 This plugin provide wrappers around several programs of `cisTEM <https://cistem.org>`_ software suite.
 
+.. image:: https://img.shields.io/pypi/v/scipion-em-cistem.svg
+        :target: https://pypi.python.org/pypi/scipion-em-cistem
+        :alt: PyPI release
+
+.. image:: https://img.shields.io/pypi/l/scipion-em-cistem.svg
+        :target: https://pypi.python.org/pypi/scipion-em-cistem
+        :alt: License
+
+.. image:: https://img.shields.io/pypi/pyversions/scipion-em-cistem.svg
+        :target: https://pypi.python.org/pypi/scipion-em-cistem
+        :alt: Supported Python versions
+
+.. image:: https://img.shields.io/sonar/quality_gate/scipion-em_scipion-em-cistem?server=https%3A%2F%2Fsonarcloud.io
+        :target: https://sonarcloud.io/dashboard?id=scipion-em_scipion-em-cistem
+        :alt: SonarCloud quality gate
+
+.. image:: https://img.shields.io/pypi/dm/scipion-em-cistem
+        :target: https://pypi.python.org/pypi/scipion-em-cistem
+        :alt: Downloads
+
+
 +--------------+----------------+--------------------+
 | prod: |prod| | devel: |devel| | support: |support| |
 +--------------+----------------+--------------------+

--- a/cistem/__init__.py
+++ b/cistem/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.0.8'
+__version__ = '3.0.9'
 _logo = "cistem_logo.png"
 _references = ['Grant2018']
 

--- a/cistem/protocols/protocol_ctffind.py
+++ b/cistem/protocols/protocol_ctffind.py
@@ -61,7 +61,7 @@ class CistemProtCTFFind(ProtCTFMicrographs):
         """ Run ctffind with required parameters """
         if self.usePowerSpectra:
             micFn = mic._powerSpectra.getFileName()
-            powerSpectraPix = self._getPsSampling()
+            powerSpectraPix = self.psSampling
         else:
             micFn = mic.getFileName()
             powerSpectraPix = None
@@ -131,6 +131,8 @@ class CistemProtCTFFind(ProtCTFMicrographs):
             mic = self._getFirstMic()
             if not hasattr(mic, "_powerSpectra"):
                 errors.append("Input micrographs do not have associated power spectra.")
+            else:
+                self.psSampling = mic._powerSpectra.getSamplingRate()
 
         if self.lowRes.get() > 50:
             errors.append("Minimum resolution cannot be > 50A.")
@@ -203,6 +205,3 @@ class CistemProtCTFFind(ProtCTFMicrographs):
     def _getFirstMic(self):
         """ Get first mic in the input set only once. """
         return self.getInputMicrographs().getFirstItem()
-
-    def _getPsSampling(self):
-        return self._getFirstMic()._powerSpectra.getSamplingRate()


### PR DESCRIPTION
Fix for the bug introduced in 3.0.8: race conditions when using self._getFirstMic()._powerSpectra.getSamplingRate() with threads