### PR TITLE
release 3.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,7 @@
     - remove psd comparison and leave only psd thumbnail
     - add eman2 requirement warning
     - calculate box size for picking
-    - scale factor for thumbnails changed to 3
+    - fix intensity scaling for thumbnails
 3.0.9 - fix race conditions after adding amplitude spectra option
 3.0.8 - add calculate from amplitude spectra option, update default values
 3.0.7 - minor fixes

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+3.1.0:
+    - optimize imports
+    - better error / exception handling
+    - create links for input mrc files
+    - fixes for using scipion scratch
+    - compute psd with eman2, remove xmipp deps
+    - remove psd comparison and leave only psd thumbnail
+    - add eman2 requirement warning
+    - calculate box size for picking
+    - scale factor for thumbnails changed to 3
 3.0.9 - fix race conditions after adding amplitude spectra option
 3.0.8 - add calculate from amplitude spectra option, update default values
 3.0.7 - minor fixes

--- a/cistem/__init__.py
+++ b/cistem/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.0.10'
+__version__ = '3.1.0'
 _logo = "cistem_logo.png"
 _references = ['Grant2018']
 
@@ -62,8 +62,8 @@ class Plugin(pwem.Plugin):
         """ Return the program binary that will be used. """
         if program == CTFFIND4_BIN:
             # if CTFFIND4_HOME is found, use it
-            path = cls.getVar(CTFFIND4_HOME, None)
-            if os.path.exists(path):
+            path = cls.getVar(CTFFIND4_HOME)
+            if pwutils.exists(path):
                 binary = os.path.join(path, 'bin', program)
             else:
                 binary = os.path.join(cls.getHome(), program)

--- a/cistem/convert/convert.py
+++ b/cistem/convert/convert.py
@@ -27,6 +27,7 @@
 import os
 import numpy as np
 from collections import OrderedDict
+
 from pwem.objects import (Coordinate, SetOfClasses2D, SetOfAverages,
                           Transform, CTFModel)
 from pwem.constants import ALIGN_PROJ

--- a/cistem/convert/dataimport.py
+++ b/cistem/convert/dataimport.py
@@ -28,6 +28,7 @@ import os
 
 import pyworkflow.utils as pwutils 
 from pwem.objects import CTFModel, SetOfParticles
+
 from .convert import readCtfModel, readSetOfParticles
 
 
@@ -55,7 +56,7 @@ class GrigorieffLabImportCTF:
                            fnBase.replace('_ctffind4', '')]
             for prefix in psdPrefixes:
                 psdFile = prefix + suffix
-                if os.path.exists(psdFile):
+                if pwutils.exists(psdFile):
                     if psdFile.endswith('.ctf'):
                         psdFile += ':mrc'
                     ctf.setPsdFile(psdFile)

--- a/cistem/protocols/program_ctffind.py
+++ b/cistem/protocols/program_ctffind.py
@@ -127,7 +127,7 @@ class ProgramCtffind:
                        help="Select this option if CTF determination "
                             "fails on images that show clear Thon rings "
                             "and should therefore yield good CTF parameters, "
-                            "or if you expect noticably elliptical Thon "
+                            "or if you expect noticeably elliptical Thon "
                             "rings and high noise.")
 
         group.addParam('fixAstig', params.BooleanParam, default=True,

--- a/cistem/protocols/protocol_refine2d.py
+++ b/cistem/protocols/protocol_refine2d.py
@@ -302,7 +302,7 @@ class CistemProtRefine2D(ProtClassify2D):
     # --------------------------- STEPS functions -----------------------------
     def continueStep(self, iterN):
         """Create a symbolic link of a previous iteration from a previous run."""
-        iterN = iterN - 1
+        iterN -= 1
         continueRun = self.continueRun.get()
         self._createWorkingDirs()
         # link particles
@@ -378,7 +378,7 @@ class CistemProtRefine2D(ProtClassify2D):
         })
 
         cmdArgs = argsStr % paramsDic
-        self.runJob(self._getProgram('refine2d'), cmdArgs,
+        self.runJob(self._getProgram(), cmdArgs,
                     cwd=self._getExtraPath(),
                     env=Plugin.getEnviron())
 
@@ -422,7 +422,7 @@ class CistemProtRefine2D(ProtClassify2D):
         })
 
         cmdArgs = argsStr % paramsDic
-        self.runJob(self._getProgram('refine2d'), cmdArgs,
+        self.runJob(self._getProgram(), cmdArgs,
                     cwd=self._getExtraPath(),
                     env=Plugin.getEnviron())
 

--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -87,7 +87,7 @@ class ProtTsCtffind(ProtTsEstimateCTF):
             pwutils.moveFile(outputPsd.replace('.mrc', '.txt'),
                              self._getTmpPath())
 
-        except RuntimeError:
+        except:
             print("ERROR: Ctffind has failed for %s" % tiFn)
 
     # --------------------------- INFO functions ------------------------------

--- a/cistem/protocols/protocol_unblur.py
+++ b/cistem/protocols/protocol_unblur.py
@@ -84,8 +84,8 @@ class CistemProtUnblur(ProtAlignMovies):
         form.addParam('doComputePSD', params.BooleanParam, default=False,
                       expertLevel=params.LEVEL_ADVANCED,
                       label="Compute PSD?",
-                      help="If Yes, the protocol will compute for each movie "
-                           "the PSD after alignment using EMAN2.")
+                      help="If Yes, the protocol will compute for each "
+                           "aligned micrograph the PSD using EMAN2.")
         form.addParam('doComputeMicThumbnail', params.BooleanParam,
                       expertLevel=params.LEVEL_ADVANCED,
                       default=False,
@@ -205,7 +205,7 @@ class CistemProtUnblur(ProtAlignMovies):
                 self._saveAlignmentPlots(movie, inputMovies.getSamplingRate())
 
                 if self._doComputeMicThumbnail():
-                    self.computeThumbnail(outMicFn, scaleFactor=3,
+                    self.computeThumbnail(outMicFn,
                                           outputFn=self._getOutputMicThumbnail(movie))
 
             if self._useWorkerThread():
@@ -399,10 +399,11 @@ eof\n
     def _doComputeMicThumbnail(self):
         return self.doComputeMicThumbnail
 
-    def _computePSD(self, inputFn, outputFn, scaleFactor=3):
+    def _computePSD(self, inputFn, outputFn, scaleFactor=6):
         """ Generate a thumbnail of the PSD with EMAN2"""
         args = "%s %s " % (inputFn, outputFn)
-        args += "--process=math.realtofft --meanshrink %s" % scaleFactor
+        args += "--process=math.realtofft --meanshrink %s " % scaleFactor
+        args += "--fixintscaling=sane"
 
         from pwem import Domain
         eman2 = Domain.importFromPlugin('eman2')

--- a/cistem/tests/__init__.py
+++ b/cistem/tests/__init__.py
@@ -1,3 +1,28 @@
+# **************************************************************************
+# *
+# *  Authors:     Grigory Sharov (gsharov@mrc-lmb.cam.ac.uk)
+# *
+# * MRC Laboratory of Molecular Biology (MRC-LMB)
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
 
 from .test_protocols_cistem import TestCtffind4
 from .test_protocols_cistem_movies import TestMoviesBase, TestUnblur

--- a/cistem/tests/test_protocols_cistem_movies.py
+++ b/cistem/tests/test_protocols_cistem_movies.py
@@ -27,9 +27,8 @@
 
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 from pwem.protocols import ProtImportMovies
-from pyworkflow.utils import magentaStr
+from pyworkflow.utils import magentaStr, exists
 
-from cistem import *
 from ..protocols import CistemProtUnblur
 
 
@@ -88,4 +87,4 @@ class TestUnblur(TestMoviesBase):
 
         for mic in outputMics:
             micFn = mic.getFileName()
-            self.assertTrue(os.path.exists(self.proj.getPath(micFn)))
+            self.assertTrue(exists(self.proj.getPath(micFn)))

--- a/cistem/viewers.py
+++ b/cistem/viewers.py
@@ -43,8 +43,7 @@ def createCtfPlot(ctfSet, ctfId):
     xplotter = EmPlotter(windowTitle='CTFFind results')
     plot_title = getPlotSubtitle(ctfModel)
     a = xplotter.createSubPlot(plot_title, 'Spacial frequency (1/A)',
-                               'Amplitude (or cross-correlation)',
-                               yformat=False)
+                               'Amplitude (or cross-correlation)')
     legendName = ['Amplitude spectrum',
                   'CTF Fit',
                   'Quality of fit']


### PR DESCRIPTION
3.1.0:
    - optimize imports
    - better error / exception handling
    - create links for input mrc files
    - fixes for using scipion scratch
    - compute psd with eman2, remove xmipp deps
    - remove psd comparison and leave only psd thumbnail
    - add eman2 requirement warning
    - calculate box size for picking
    - fix intensity scaling for thumbnails
 