### PR TITLE
* Creating a method to tolerate imports errors

### DIFF
--- a/cistem/protocols/__init__.py
+++ b/cistem/protocols/__init__.py
@@ -24,13 +24,28 @@
 # *
 # **************************************************************************
 
+import contextlib
+
 from .protocol_ctffind import CistemProtCTFFind
 from .protocol_unblur import CistemProtUnblur
 from .protocol_picking import CistemProtFindParticles
 from .protocol_refine2d import CistemProtRefine2D
 
-try:
+# This is a prototype and will likely be move to pyworkflow soon
+# Once in pyworkflow, this method can be removed and imported from there
+@contextlib.contextmanager
+def weakImport(package):
+    """
+     This method can be use to tolerate imports that may fail, e.g imports
+    :param package: name of the package that is expected to fail
+    """
+    try:
+        yield
+    except ImportError as e:
+        if "'%s'" % package not in str(e):
+            raise e
+
+
+with weakImport('tomo'):
     from .protocol_ts_ctffind import CistemProtTsCtffind
-except ImportError as e:
-    if "'tomo'" not in str(e):
-        raise e
+

--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -34,13 +34,8 @@ from pwem.protocols import EMProtocol
 
 from .program_ctffind import ProgramCtffind
 
-try:
-    from tomo.objects import CTFTomo
-    from tomo.protocols import ProtTsEstimateCTF
-except ImportError as e:
-    if "'tomo'" not in str(e):
-        raise e
-
+from tomo.objects import CTFTomo
+from tomo.protocols import ProtTsEstimateCTF
 
 class CistemProtTsCtffind(ProtTsEstimateCTF):
     """ CTF estimation on a set of tilt series using CTFFIND4. """

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['scipion-em', 'scipion-em-tomo'],  # Optional
+    install_requires=['scipion-em'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
* Creating a method to tolerate imports errors
* Removed scipion-em-tomo from requirements.
  - When cistem plugin is installed, tomo is installed from pypi. All tomo protocols are visible for the users