### PR TITLE
Fixed dimensions of output sets

### DIFF
--- a/cistem/protocols/protocol_tomo_resample.py
+++ b/cistem/protocols/protocol_tomo_resample.py
@@ -140,6 +140,7 @@ eof\n
 
         self._defineOutputs(**{OUTPUT_TOMO_NAME: outTomoSet})
         self._defineTransformRelation(self.inTomograms, outTomoSet)
+        outTomoSet.updateDim()
 
     # --------------------------- INFO functions -----------------------------------
     def _citations(self):

--- a/cistem/protocols/protocol_ts_resample.py
+++ b/cistem/protocols/protocol_ts_resample.py
@@ -134,6 +134,7 @@ eof\n
 
         self._defineOutputs(**{OUTPUT_TS_NAME: outTsSet})
         self._defineTransformRelation(self.inputSetOfTiltSeries, outTsSet)
+        outTsSet.updateDim()
 
     # --------------------------- INFO functions -----------------------------------
     def _citations(self):


### PR DESCRIPTION
When resampling tomograms and tilt series, the output sets still retained the dimensions of the input sets, even though the objects they contained were correct. This PR fixes this bug.