### PR TITLE
Update the acquisition order in the CTFTomo objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.8.1:
+ Developers: update the acquisition order in the CTFTomo objects (field added to that class in scipion-em-tomo v3.7.0).
 3.8: new protocols to resample tomo and TS
 3.7.1: fix an obsolete import in the viewer.
 3.7:

--- a/cistem/__init__.py
+++ b/cistem/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.8'
+__version__ = '3.8.1'
 _logo = "cistem_logo.png"
 _references = ['Grant2018']
 

--- a/cistem/convert/dataimport.py
+++ b/cistem/convert/dataimport.py
@@ -84,6 +84,7 @@ class GrigorieffLabImportCTF:
             if not ti.isEnabled():
                 newCtfTomo.setEnabled(False)
             newCtfTomo.setIndex(i + 1)
+            newCtfTomo.setAcquisitionOrder(ti.getAcquisitionOrder())
             output.append(newCtfTomo)
 
         output.calculateDefocusUDeviation()


### PR DESCRIPTION
In scipion-em-tomo version 3.7.0, the acquisition order has been added to the CTFTomo to provide a robust field to match between tilt-images and CTFTomo when they come 
from different places, such as in Reliontomo prepare or IMOD ctf correction. It opens a way to robustly deal with re-stacked files, excluded vies, etc.