### PR TITLE
TsCtffind - fill the acquisition order in the createOutputStep

### DIFF
--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -166,6 +166,7 @@ class CistemProtTsCtffind(EMProtocol):
         for i, tiltImage in enumerate(ts.iterItems()):
             ctfTomo = self._getCtfTi(ctf, ctfResult, i, mdObj.outputPsd)
             ctfTomo.setIndex(tiltImage.getIndex())
+            ctfTomo.setAcquisitionOrder(tiltImage.getAcquisitionOrder())
             tiltImage.setCTF(ctfTomo)
             newCTFTomoSeries.append(ctfTomo)
 


### PR DESCRIPTION
I forgot to update the CTF acquisition order in the TsCtfEstimation - createOutputSTep 