### PR TITLE
New opts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.10: add tomo options to measure sample tilt and thickness
 3.9.3
   Developers:
    - Resume hidden params in CTF estimations removed

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,8 @@
-3.10: add tomo options to measure sample tilt and thickness
+3.10:
+    - add tomo options to measure sample tilt and thickness
+    - estimate ice thickness as in Relion, output rlnIceThickness column
+    - add new binary ctffind 5.0.2
+    - 5.0.2 no longer limits lowest resolution to 50A
 3.9.3
   Developers:
    - Resume params in CTF estimations removed

--- a/README.rst
+++ b/README.rst
@@ -51,10 +51,10 @@ b) Developer's version
 
 **Important:** Starting from plugin v3.9, the config variables have been renamed. See: `scipion3 config -p cistem`
 
-cisTEM binaries will be installed automatically with the plugin, but you can also link an existing installation.
+cisTEM and CTFFind binaries will be installed automatically with the plugin, but you can also link an existing installation.
 
-    * Default installation path assumed is ``software/em/cistem-1.0.0-beta``, if you want to change it, set *CISTEM_HOME* in ``scipion.conf`` file pointing to the folder where the cisTEM is installed.
-    * It's possible to use CTFFIND installed separately from cisTEM by defining *CTFFIND_HOME* variable in ``scipion.conf``. Setting this value will have the priority over Ctffind inside cisTEM.
+    * Default cisTEM installation path assumed is ``software/em/cistem-1.0.0-beta``, if you want to change it, set *CISTEM_HOME* in ``scipion.conf`` file pointing to the folder where the cisTEM is installed.
+    * Default CTFFind installation path assumed is ``software/em/ctffind-5.0.2``,if you want to change it, set *CTFFIND_HOME* in ``scipion.conf`` file pointing to the folder where CTFFind is installed.
 
 A complete list of tests can be seen by executing ``scipion test --show --grep cistem``
 
@@ -62,8 +62,8 @@ Supported versions
 ------------------
 
 * 1.0.0-beta (cistem)
-* 4.1.13, 4.1.14 (ctffind4)
-* 5.0 (ctffind5)
+* 4.1.14 (ctffind4)
+* 5.0, 5.0.2 (ctffind5)
 
 Licenses
 --------

--- a/cistem/__init__.py
+++ b/cistem/__init__.py
@@ -25,6 +25,7 @@
 # **************************************************************************
 
 import os
+import re
 
 import pwem
 import pyworkflow.utils as pwutils
@@ -46,13 +47,13 @@ class Plugin(pwem.Plugin):
     @classmethod
     def _defineVariables(cls):
         cls._defineEmVar(CISTEM_HOME, 'cistem-1.0.0-beta')
-        cls._defineEmVar(CTFFIND_HOME, 'ctffind-5.0')
+        cls._defineEmVar(CTFFIND_HOME, 'ctffind-5.0.2')
 
     @classmethod
     def getActiveVersion(cls, *args):
         """ Return the env name that is currently active. """
         ctffind = cls.getVar(CTFFIND_HOME)
-        return ctffind.split()[-1].split("-")[-1]
+        return re.search(r"ctffind-([0-9a-zA-Z.]+)$", ctffind).group(1)
 
     @classmethod
     def getEnviron(cls):
@@ -83,10 +84,10 @@ class Plugin(pwem.Plugin):
         env.addPackage('cistem', version='1.0.0-beta',
                        url="https://grigoriefflab.umassmed.edu/sites/default/files/cistem-1.0.0-beta-intel-linux.tar.gz",
                        default=True)
-        env.addPackage('ctffind4', version='4.1.13',
-                       tar='ctffind4-4.1.13.tgz')
         env.addPackage('ctffind4', version='4.1.14',
-                       tar='ctffind4-4.1.14.tgz',
-                       default=True)
+                       tar='ctffind4-4.1.14.tgz')
         env.addPackage('ctffind', version='5.0',
                        tar='ctffind-5.0.tgz')
+        env.addPackage('ctffind', version='5.0.2',
+                       tar='ctffind-5.0.2.tgz',
+                       default=True)

--- a/cistem/__init__.py
+++ b/cistem/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.9.3'
+__version__ = '3.10'
 _logo = "cistem_logo.png"
 _references = ['Grant2018']
 
@@ -46,7 +46,13 @@ class Plugin(pwem.Plugin):
     @classmethod
     def _defineVariables(cls):
         cls._defineEmVar(CISTEM_HOME, 'cistem-1.0.0-beta')
-        cls._defineEmVar(CTFFIND_HOME, 'ctffind4-4.1.14')
+        cls._defineEmVar(CTFFIND_HOME, 'ctffind-5.0')
+
+    @classmethod
+    def getActiveVersion(cls, *args):
+        """ Return the env name that is currently active. """
+        ctffind = cls.getVar(CTFFIND_HOME)
+        return ctffind.split()[-1].split("-")[-1]
 
     @classmethod
     def getEnviron(cls):

--- a/cistem/bibtex.py
+++ b/cistem/bibtex.py
@@ -26,15 +26,15 @@
 # **************************************************************************
 """
 
-@article {Elferich2024,
-	author = {Johannes Elferich and Lingli Kong and Ximena Zottig and Nikolaus Grigorieff},
-	title = {CTFFIND5 provides improved insight into quality, tilt and thickness of TEM samples},
-	year = {2024},
-	doi = {10.1101/2024.02.26.582023},
-	publisher = {Cold Spring Harbor Laboratory},
-	URL = {https://www.biorxiv.org/content/early/2024/02/28/2024.02.26.582023},
-	journal = {bioRxiv}
+@article{Elferich2024,
+title={CTFFIND5 provides improved insight into quality, tilt and thickness of TEM samples},
+journal={eLife},
+url={http://dx.doi.org/10.7554/eLife.97227.1},
+DOI={https://dx.doi.org/10.7554/elife.97227.1},
+author={Elferich, Johannes and Kong, Lingli and Zottig, Ximena and Grigorieff, Nikolaus},
+year={2024}
 }
+
 
 @article{Grant2018,
 title = "cisTEM, user-friendly software for single-particle image processing",

--- a/cistem/convert/convert.py
+++ b/cistem/convert/convert.py
@@ -116,10 +116,10 @@ def parseCtffindOutput(filename, avrot=False):
             # Reshape into a 3D array where each "block" of 6 lines forms one slice along the first axis
             reshaped_data = result.reshape(-1, 6, result.shape[1])
             # Apply the mask to the first line of each 6-line block
+            # See details at https://github.com/3dem/relion-devel/commit/fceb6f687a09151dd60fd6e0ca46289798223bab
             mask = np.logical_and(reshaped_data[:, 0, :] >= 0.25, reshaped_data[:, 0, :] <= 0.28)
             # Compute the sum of the absolute values of the second line where the mask is True
             rotAvgArray = np.sum(np.abs(reshaped_data[:, 1, :]) * mask, axis=1)
-
             return rotAvgArray
         else:
             return result

--- a/cistem/convert/dataimport.py
+++ b/cistem/convert/dataimport.py
@@ -28,7 +28,7 @@
 
 import os.path
 
-import pyworkflow.utils as pwutils 
+import pyworkflow.utils as pwutils
 from pwem.objects import CTFModel, SetOfParticles
 
 from .convert import (readCtfModel, readSetOfParticles,
@@ -50,11 +50,14 @@ class GrigorieffLabImportCTF:
         :param fileName: input file to be parsed
         :return: CTFModel object
         """
+        fnBase = pwutils.removeExt(fileName)
+        avrotFn = fileName + "_avrot.txt"
+        avrotFn = None if not os.path.exists(avrotFn) else avrotFn
+
         ctf = CTFModel()
         ctf.setMicrograph(mic)
-        ctf = readCtfModel(ctf, fileName)
-        
-        fnBase = pwutils.removeExt(fileName)
+        ctf = readCtfModel(ctf, fileName, avrotFn)
+
         psdFile = self._findPsdFile(fnBase)
         ctf.setPsdFile(psdFile)
 
@@ -70,17 +73,25 @@ class GrigorieffLabImportCTF:
         fnBase = os.path.join(os.path.dirname(fileName), tsId)
         outputPsd = self._findPsdFile(fnBase)
         ctfResult = parseCtffindOutput(fileName)
+        avrotFn = pwutils.removeExt(fileName) + "_avrot.txt"
+        if os.path.exists(avrotFn):
+            avrotResult = parseCtffindOutput(avrotFn, avrot=True)
+        else:
+            avrotResult = None
+
         ctf = CTFModel()
         counter = 0
 
         for i, ti in enumerate(ts):
             if ti.isEnabled():
-                self.getCtfTi(ctf, ctfResult, counter, outputPsd)
+                self.getCtfTi(ctf, ctfResult, avrotResult, counter, outputPsd)
                 counter += 1
             else:
                 ctf.setWrongDefocus()
 
             newCtfTomo = CTFTomo.ctfModelToCtfTomo(ctf)
+            if hasattr(ctf, "_rlnIceRingDensity"):
+                newCtfTomo.copyAttributes(ctf, '_rlnIceRingDensity')
             if not ti.isEnabled():
                 newCtfTomo.setEnabled(False)
             newCtfTomo.setIndex(i + 1)
@@ -88,9 +99,9 @@ class GrigorieffLabImportCTF:
             output.append(newCtfTomo)
 
     @staticmethod
-    def getCtfTi(ctf, ctfArray, tiIndex, psdStack=None):
+    def getCtfTi(ctf, ctfArray, rotAvgArray, tiIndex, psdStack=None):
         """ Parse the CTF object estimated for this Tilt-Image. """
-        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray, item=tiIndex)
+        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray, rotAvgArray, item=tiIndex)
         if psdStack is not None:
             ctf.setPsdFile(f"{tiIndex + 1}@" + psdStack)
 

--- a/cistem/convert/dataimport.py
+++ b/cistem/convert/dataimport.py
@@ -52,7 +52,7 @@ class GrigorieffLabImportCTF:
         """
         ctf = CTFModel()
         ctf.setMicrograph(mic)
-        readCtfModel(ctf, fileName)
+        ctf = readCtfModel(ctf, fileName)
         
         fnBase = pwutils.removeExt(fileName)
         psdFile = self._findPsdFile(fnBase)
@@ -87,13 +87,10 @@ class GrigorieffLabImportCTF:
             newCtfTomo.setAcquisitionOrder(ti.getAcquisitionOrder())
             output.append(newCtfTomo)
 
-        output.calculateDefocusUDeviation()
-        output.calculateDefocusVDeviation()
-
     @staticmethod
     def getCtfTi(ctf, ctfArray, tiIndex, psdStack=None):
         """ Parse the CTF object estimated for this Tilt-Image. """
-        readCtfModelStack(ctf, ctfArray, item=tiIndex)
+        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray, item=tiIndex)
         if psdStack is not None:
             ctf.setPsdFile(f"{tiIndex + 1}@" + psdStack)
 

--- a/cistem/protocols/program_ctffind.py
+++ b/cistem/protocols/program_ctffind.py
@@ -188,7 +188,7 @@ class ProgramCtffind:
         :param psdFile: if defined, set PSD for the CTF model
         """
         ctf = CTFModel()
-        readCtfModel(ctf, filename)
+        ctf = readCtfModel(ctf, filename)
         if psdFile:
             ctf.setPsdFile(psdFile)
 

--- a/cistem/protocols/program_ctffind.py
+++ b/cistem/protocols/program_ctffind.py
@@ -134,7 +134,7 @@ class ProgramCtffind:
                             'fits. Disable this option if you expect '
                             'large astigmatism.')
         group.addParam('astigmatism', params.FloatParam,
-                       default=100.0, condition='fixAstig',
+                       default=200.0, condition='fixAstig',
                        label='Tolerated astigmatism (A)',
                        expertLevel=params.LEVEL_ADVANCED,
                        help='When restraining astigmatism, astigmatism values '
@@ -205,8 +205,6 @@ class ProgramCtffind:
         paramDict['fixAstig'] = "yes" if protocol.fixAstig else "no"
         paramDict['astigmatism'] = protocol.astigmatism.get()
         paramDict['lowRes'] = protocol.lowRes.get()
-        if paramDict['lowRes'] > 50:
-            paramDict['lowRes'] = 50
         paramDict['highRes'] = protocol.highRes.get()
         # defocus is in Angstroms now
         paramDict['minDefocus'] = protocol.minDefocus.get()

--- a/cistem/protocols/program_ctffind.py
+++ b/cistem/protocols/program_ctffind.py
@@ -181,14 +181,15 @@ class ProgramCtffind:
         paramDict.update(kwargs)
         return self._program, self._args % paramDict
 
-    def parseOutputAsCtf(self, filename, psdFile=None):
+    def parseOutputAsCtf(self, ctfFn, rotAvgFn=None, psdFile=None):
         """ Parse the output file and build the CTFModel object
         with the values.
-        :param filename: input file to parse
+        :param ctfFn: input CTF file to parse
+        :param rotAvgFn: extra input file with power spectra
         :param psdFile: if defined, set PSD for the CTF model
         """
         ctf = CTFModel()
-        ctf = readCtfModel(ctf, filename)
+        ctf = readCtfModel(ctf, ctfFn, rotAvgFn)
         if psdFile:
             ctf.setPsdFile(psdFile)
 
@@ -221,6 +222,19 @@ class ProgramCtffind:
 
         paramDict['slowSearch'] = "yes" if protocol.slowSearch else "no"
 
+        tomo = hasattr(protocol, "measureTilt")
+        paramDict['measureTilt'] = "yes" if (tomo and protocol.measureTilt) else "no"
+        if tomo and protocol.measureThickness:
+            paramDict['measureThickness'] = "yes"
+            paramDict['search1D'] = "yes" if protocol.search1D else "no"
+            paramDict['refine2D'] = "yes" if protocol.refine2D else "no"
+            paramDict['lowResNodes'] = protocol.lowResNodes.get()
+            paramDict['highResNodes'] = protocol.highResNodes.get()
+            paramDict['useRoundedSquare'] = "yes" if protocol.useRoundedSquare else "no"
+            paramDict['downweightNodes'] = "yes" if protocol.downweightNodes else "no"
+        else:
+            paramDict['measureThickness'] = "no"
+
         args = """   << eof > %(ctffindOut)s
 %(micFn)s
 %(ctffindPSD)s
@@ -238,8 +252,8 @@ no
 %(slowSearch)s
 %(fixAstig)s
 %(phaseShift)s
-no
-no
+%(measureTilt)s
+%(measureThickness)s
 no
 eof\n
 """
@@ -266,4 +280,15 @@ eof\n
                                 '%(minPhaseShift)f\n'
                                 '%(maxPhaseShift)f\n'
                                 '%(stepPhaseShift)f')
+
+        if tomo and protocol.measureThickness:
+            args = args.replace('%(measureThickness)s',
+                                '%(measureThickness)s\n'
+                                '%(search1D)s\n'
+                                '%(refine2D)s\n'
+                                '%(lowResNodes)s\n'
+                                '%(highResNodes)s\n'
+                                '%(useRoundedSquare)s\n'
+                                '%(downweightNodes)s')
+
         return args, paramDict

--- a/cistem/protocols/protocol_ctffind.py
+++ b/cistem/protocols/protocol_ctffind.py
@@ -122,6 +122,7 @@ class CistemProtCTFFind(ProtCTFMicrographs):
         """ Redefined func from the base class. """
         psd = self._getPsdPath(mic)
         ctfModel = self._ctfProgram.parseOutputAsCtf(self._getCtfOutPath(mic),
+                                                     self._getCtfAvrotPath(mic),
                                                      psdFile=psd)
         ctfModel.setMicrograph(mic)
         pwutils.cleanPath(self._getCtfOutPath(mic))
@@ -201,6 +202,9 @@ class CistemProtCTFFind(ProtCTFMicrographs):
 
     def _getCtfOutPath(self, mic):
         return self._getMicExtra(mic, 'ctf.txt')
+
+    def _getCtfAvrotPath(self, mic):
+        return self._getMicExtra(mic, 'ctf_avrot.txt')
 
     def _getCTFModel(self, defocusU, defocusV, defocusAngle, psdFile):
         ctf = CTFModel()

--- a/cistem/protocols/protocol_ctffind.py
+++ b/cistem/protocols/protocol_ctffind.py
@@ -146,9 +146,6 @@ class CistemProtCTFFind(ProtCTFMicrographs):
             else:
                 self.psSampling = mic._powerSpectra.getSamplingRate()
 
-        if self.lowRes.get() > 50:
-            errors.append("Minimum resolution cannot be > 50A.")
-
         valueStep = round(self.stepPhaseShift.get(), 2)
         valueMin = round(self.minPhaseShift.get(), 2)
         valueMax = round(self.maxPhaseShift.get(), 2)

--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -112,12 +112,15 @@ class CistemProtTsCtffind(EMProtocol):
             form.addParam('measureTilt', params.BooleanParam,
                           default=False,
                           label="Determine sample tilt?",
-                          help="Measure tilt axis and angle.")
+                          help="Measure tilt axis and angle.\n"
+                               "NOTE: this will slow down computation x100 times!")
 
             group = form.addGroup('Thickness')
             group.addParam('measureThickness', params.BooleanParam,
                            default=False,
-                           label="Determine sample thickness?")
+                           label="Determine sample thickness?\n"
+                                 "NOTE: this can improve the results with a tiny "
+                                 "computing time penalty!")
             group.addParam('search1D', params.BooleanParam,
                            default=True, condition='measureThickness',
                            label="Use brute force 1D search?",
@@ -251,9 +254,6 @@ class CistemProtTsCtffind(EMProtocol):
     # --------------------------- INFO functions ------------------------------
     def _validate(self):
         errors = []
-
-        if self.lowRes.get() > 50:
-            errors.append("Minimum resolution cannot be > 50A.")
 
         valueStep = round(self.stepPhaseShift.get(), 2)
         valueMin = round(self.minPhaseShift.get(), 2)

--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -29,6 +29,7 @@
 
 import os
 from enum import Enum
+from collections import namedtuple
 
 from pwem.protocols import EMProtocol
 from pyworkflow.object import Set
@@ -38,16 +39,19 @@ import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
 from pwem.objects import CTFModel
 from pwem import emlib
-from collections import namedtuple
-from tomo.protocols.protocol_ts_estimate_ctf import createCtfParams
-from .program_ctffind import ProgramCtffind
-from ..convert import readCtfModelStack, parseCtffindOutput
+
 from tomo.objects import CTFTomo, SetOfCTFTomoSeries, CTFTomoSeries
+from tomo.protocols.protocol_ts_estimate_ctf import createCtfParams
+
+from cistem.protocols.program_ctffind import ProgramCtffind
+from cistem.convert import readCtfModelStack, parseCtffindOutput
+from cistem import Plugin
+
 
 MRCS_EXT = ".mrcs"
 # create simple, lightweight data structures similar to a class, but without the overhead of defining a full class
 CistemTsCtfMd = namedtuple('CistemTsCtfMd',
-                           ['ts', 'tsFn', 'outputLog', 'outputPsd'])
+                           ['ts', 'tsFn', 'outputLog', 'outputRotAvg', 'outputPsd'])
 
 
 class TsCtffindOutputs(Enum):
@@ -59,7 +63,7 @@ class CistemProtTsCtffind(EMProtocol):
     ratio (SNR) of Fourier components of each image. Those Fourier components
     where the CTF is near 0.0 have very low SNR compared to others. It is therefore
     essential to obtain accurate estimates of the CTF for each image so that
-    data from multiple imges may be combined in an optimal manner during later
+    data from multiple images may be combined in an optimal manner during later
     processing.\n
 
     You can use CTFfind (Rohou & Grigorieff, 2015) to estimate CTF parameter values
@@ -94,11 +98,58 @@ class CistemProtTsCtffind(EMProtocol):
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form, stream=False):
         form.addSection(label='Input')
-        form.addParam('inputTiltSeries', params.PointerParam, important=True,
+        form.addParam('inputTiltSeries', params.PointerParam,
+                      important=True,
                       pointerClass='SetOfTiltSeries, SetOfCTFTomoSeries',
                       label='Tilt series')
-
+        # ctffind resamples input mics automatically
+        form.addHidden('ctfDownFactor', params.FloatParam,
+                       default=1.)
         ProgramCtffind.defineProcessParams(form)
+
+        if Plugin.getActiveVersion().startswith('5'):
+            form.addSection(label='Tomo')
+            form.addParam('measureTilt', params.BooleanParam,
+                          default=False,
+                          label="Determine sample tilt?",
+                          help="Measure tilt axis and angle.")
+
+            group = form.addGroup('Thickness')
+            group.addParam('measureThickness', params.BooleanParam,
+                           default=False,
+                           label="Determine sample thickness?")
+            group.addParam('search1D', params.BooleanParam,
+                           default=True, condition='measureThickness',
+                           label="Use brute force 1D search?",
+                           help="CTFFIND5 will further refine thickness "
+                                "and defocus by calculating the normalized "
+                                "cross-correlation between the radial average "
+                                "of the power spectrum (corrected for "
+                                "astigmatism) and CTF, searching systematically"
+                                "for the best combination of thickness in the "
+                                "range of 50-400 nm in 10 nm steps, and defocus "
+                                "in the range of +/-200 nm from the previously "
+                                "fitted value, also in 10 nm steps.")
+            group.addParam('refine2D', params.BooleanParam,
+                           default=True, condition='measureThickness',
+                           label="Use 2D refinement?",
+                           help="CTFFIND5 will optimize thickness, defocus and "
+                                "amplitude contrast using the same conjugate "
+                                "gradient algorithm used in CTFFIND4 and "
+                                "the normalized cross-correlation between CTF "
+                                "and the 2D power spectrum as a scoring function.")
+            line = group.addLine('Resolution limit for nodes (A)',
+                                 condition='measureThickness')
+            line.addParam('lowResNodes', params.FloatParam,
+                          default=30., label='Min')
+            line.addParam('highResNodes', params.FloatParam,
+                          default=3., label='Max')
+            group.addParam('useRoundedSquare', params.BooleanParam,
+                           default=False, condition='measureThickness',
+                           label="Use rounded square for nodes?")
+            group.addParam('downweightNodes', params.BooleanParam,
+                           default=False, condition='measureThickness',
+                           label="Downweight nodes?")
 
     # --------------------------- STEPS functions -----------------------------
     def _insertAllSteps(self):
@@ -126,6 +177,7 @@ class CistemProtTsCtffind(EMProtocol):
                 ts=ts.clone(ignoreAttrs=[]),
                 tsFn=self._getTmpPath(ts.getTsId() + MRCS_EXT),
                 outputLog=outputLog,
+                outputRotAvg=outputLog.replace(".txt", "_avrot.txt"),
                 outputPsd=outputLog.replace(".txt", MRCS_EXT)
             )
             self.tsCtfMdList.append(md)
@@ -160,43 +212,38 @@ class CistemProtTsCtffind(EMProtocol):
                 outCtfSet.enableAppend()
             else:
                 outCtfSet = SetOfCTFTomoSeries.create(self._getPath(),
-                                                      template='ctfTomoSeriess%s.sqlite')
+                                                      template='ctfTomoSeries%s.sqlite')
                 outCtfSet.setSetOfTiltSeries(self.inTsSet)
                 outCtfSet.setStreamState(Set.STREAM_OPEN)
                 self._defineOutputs(**{self._possibleOutputs.CTFs.name: outCtfSet})
                 self._defineSourceRelation(self.inTsSet, outCtfSet)
 
             ts = mdObj.ts
-            outputLog = mdObj.outputLog
 
             # Generate the current CTF tomo series item
-            newCTFTomoSeries = CTFTomoSeries()
+            newCTFTomoSeries = CTFTomoSeries(tsId=ts.getTsId(),
+                                             tiltSeriesPointer=ts)
             newCTFTomoSeries.copyInfo(ts)
-            newCTFTomoSeries.setTiltSeries(ts)
             newCTFTomoSeries.setObjId(ts.getObjId())
-            newCTFTomoSeries.setTsId(ts.getTsId())
             outCtfSet.append(newCTFTomoSeries)
 
             # Generate the ti CTF and populate the corresponding CTF tomo series
-            ctfResult = parseCtffindOutput(outputLog)
+            ctfResult = parseCtffindOutput(mdObj.outputLog)
+            avrotResult = parseCtffindOutput(mdObj.outputRotAvg, avrot=True)
             ctf = CTFModel()
             for i, tiltImage in enumerate(ts.iterItems()):
-                ctfTomo = self._getCtfTi(ctf, ctfResult, i, mdObj.outputPsd)
+                ctfTomo = self._getCtfTi(ctf, ctfResult, avrotResult, i, mdObj.outputPsd)
                 ctfTomo.setIndex(tiltImage.getIndex())
                 ctfTomo.setAcquisitionOrder(tiltImage.getAcquisitionOrder())
                 tiltImage.setCTF(ctfTomo)
                 newCTFTomoSeries.append(ctfTomo)
 
             outCtfSet.update(newCTFTomoSeries)
-        # This should be indented once pyworkflow 3.6.1 is released. It will work the same way, but will be more
-        # efficient as less activate/release of the threads will be carried out
+
         self._store()
 
     def closeStep(self):
-        outCtfSet = self.getOutputCtfTomoSet()
-        outCtfSet.setStreamState(Set.STREAM_CLOSED)
-        outCtfSet.write()
-        self._store()
+        self._closeOutputSet()
 
     # --------------------------- INFO functions ------------------------------
     def _validate(self):
@@ -217,15 +264,20 @@ class CistemProtTsCtffind(EMProtocol):
         return errors
 
     def _citations(self):
-        return ["Mindell2003", "Rohou2015"]
+        return ["Mindell2003", "Rohou2015", "Elferich2024"]
 
     # --------------------------- UTILS functions -----------------------------
     @staticmethod
-    def _getCtfTi(ctf, ctfArray, tiIndex, psdStack):
+    def _getCtfTi(ctf, ctfArray, rotAvgArray, tiIndex, psdStack):
         """ Parse the CTF object estimated for this Tilt-Image. """
-        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray, item=tiIndex)
+        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray,
+                                                                rotAvgArray,
+                                                                item=tiIndex)
         ctf.setPsdFile(f"{tiIndex + 1}@" + psdStack)
         ctfTomo = CTFTomo.ctfModelToCtfTomo(ctf)
+        if hasattr(ctf, "_rlnIceRingDensity"):
+            ctfTomo.copyAttributes(ctf, '_rlnIceRingDensity')
+
         return ctfTomo
 
     def _getInputTs(self, pointer=False):

--- a/cistem/protocols/protocol_ts_ctffind.py
+++ b/cistem/protocols/protocol_ts_ctffind.py
@@ -223,7 +223,7 @@ class CistemProtTsCtffind(EMProtocol):
     @staticmethod
     def _getCtfTi(ctf, ctfArray, tiIndex, psdStack):
         """ Parse the CTF object estimated for this Tilt-Image. """
-        readCtfModelStack(ctf, ctfArray, item=tiIndex)
+        ctf, tiltAxis, tiltAngle, thickness = readCtfModelStack(ctf, ctfArray, item=tiIndex)
         ctf.setPsdFile(f"{tiIndex + 1}@" + psdStack)
         ctfTomo = CTFTomo.ctfModelToCtfTomo(ctf)
         return ctfTomo

--- a/cistem/tests/tomo_tests.py
+++ b/cistem/tests/tomo_tests.py
@@ -68,10 +68,10 @@ with weakImport('tomo'):
         def testCistemCtfFind(self):
             print(magentaStr("\n==> Testing cistem - ctffind:"))
             protCTF = CistemProtTsCtffind(inputTiltSeries=self.inputSoTS,
-                                          lowRes=50,
-                                          highRes=4,
-                                          minDefocus=15000,
-                                          maxDefocus=50000,
+                                          lowRes=30,
+                                          highRes=3,
+                                          minDefocus=10000,
+                                          maxDefocus=20000,
                                           numberOfThreads=3)  # 1 per each TS plus the main one
             self.launchProtocol(protCTF, wait=True)
             outCtfs = getattr(protCTF, protCTF._possibleOutputs.CTFs.name, None)


### PR DESCRIPTION
closes #85
closes #93

    - add tomo options to measure sample tilt and thickness
    - estimate ice thickness as in Relion, output rlnIceThickness column
    - add new binary ctffind 5.0.2
    - 5.0.2 no longer limits lowest resolution to 50A

New binaries can be downloaded via scipion

Notes:

- ice thickness is measured automatically by default and saved into _rlnIceThickness column
- tilt angle/axis measurement for tomo slows down computation by over x100 times (each tilt image will take 3 minutes), it is not saved in the database. It can only run on 1 CPU.
- sample thickness measurement slows down computation only x2 times (an extra second) and should result in better CTF fits for tomo. It is currently not saved into db either, only in the logs.
